### PR TITLE
fix(events): updated events icon to replace the not working one

### DIFF
--- a/resources/events.mdx
+++ b/resources/events.mdx
@@ -1,7 +1,7 @@
 ---
 title: Events
 description: "All available toggleable events within bleed."
-icon: waypoints
+icon: location-dot
 ---
 
 | Event                 | Description                                            |


### PR DESCRIPTION
Mintlify uses Font Awesome as its icon provider. The previously used icon is not supported by Font Awesome, which caused it to render incorrectly or not at all. I replaced it with a visually similar and supported icon from the Font Awesome library to ensure consistent display.